### PR TITLE
feature/CON-686-virus-scanner-performance

### DIFF
--- a/app/models/unchecked_document.rb
+++ b/app/models/unchecked_document.rb
@@ -7,6 +7,6 @@ class UncheckedDocument < ApplicationRecord
   mount_uploader :document_file, DocumentFileUploader
 
   def run_virus_scan
-    VirusScanner.new(id).scan if document_file.file.try(:exists?)
+    VirusScanner.new(id).scan
   end
 end

--- a/lib/virus_scanner.rb
+++ b/lib/virus_scanner.rb
@@ -30,7 +30,7 @@ class VirusScanner
 
   def log_safe
     @document.state = 'safe'
-    @document.save
+    @document.save(validate: false)
     remove_unchecked_document_file
   end
 
@@ -51,6 +51,6 @@ class VirusScanner
 
   def remove_unchecked_document_file
     @unchecked_document.remove_document_file!
-    @unchecked_document.save
+    @unchecked_document.save(validate: false)
   end
 end

--- a/spec/models/unchecked_document_spec.rb
+++ b/spec/models/unchecked_document_spec.rb
@@ -669,4 +669,22 @@ RSpec.describe UncheckedDocument, type: :model do
       end
     end
   end
+
+  describe 'db constraints' do
+    let(:unchecked_document) { create(:unchecked_document) }
+
+    context 'when document does not exist' do
+      it 'does  raise an error' do
+        unchecked_document.document = nil
+        expect { unchecked_document.save(validate: false) }.to raise_error(ActiveRecord::NotNullViolation)
+      end
+    end
+
+    context 'when document does not exist' do
+      it 'does not raise an error' do
+        unchecked_document.document = create(:document)
+        expect { unchecked_document.save(validate: false) }.to_not raise_error(ActiveRecord::NotNullViolation)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Saving document and unchecked document without validating to avoid calling CLAMAV twice. Also removed unnecessary check for document presence from the model as we already check for this in the controller.
