### PR TITLE
Clamby configuration set to run in multiple ENVS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:3.0.3
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  nodejs \
+  clamav \
+  clamav-daemon
+
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler && bundle install --jobs 20 --retry 5
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate
+    return if request.path == '/health_check'
+
     request.headers['Authorization'] = request.headers['x-api-key']
     authenticate_or_request_with_http_basic do |source_app, api_key|
       @client = Client.find_by(source_app: source_app)

--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,0 +1,5 @@
+class HealthCheckController < ApplicationController
+  def index
+    render json: { status: 'ok' }
+  end
+end

--- a/config/antivirus/clamd.conf
+++ b/config/antivirus/clamd.conf
@@ -1,0 +1,2 @@
+TCPAddr virus_checker
+TCPSocket 3310

--- a/config/antivirus/clamd.conf
+++ b/config/antivirus/clamd.conf
@@ -1,2 +1,2 @@
-TCPAddr virus_checker
+TCPAddr localhost
 TCPSocket 3310

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -7,15 +7,15 @@ if Rails.env.test? || Rails.env.development?
                      error_file_virus: true,
                      output_level: 'high'
                    })
-
 else
   Clamby.configure({
                      daemonize: true,
                      stream: true,
+                     error_clamscan_client_error: true,
                      error_clamscan_missing: true,
                      error_file_missing: true,
                      error_file_virus: true,
-                     config_file: '.apt/etc/clamav/clamd.conf'
+                     config_file: '/app/config/antivirus/clamd.conf',
+                     output_level: 'high'
                    })
-
 end

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,32 +1,30 @@
 if Rails.env.test? || Rails.env.development?
   Clamby.configure({
-    daemonize: true,
-    stream: true,
-    error_clamscan_missing: true,
-    error_file_missing: true,
-    error_file_virus: true,
-    output_level: 'high'
-  })
+                     daemonize: true,
+                     stream: true,
+                     error_clamscan_missing: true,
+                     error_file_missing: true,
+                     error_file_virus: true,
+                     output_level: 'high'
+                   })
+elsif ENV['AWS_NATIVE'] == 'true'
+  Clamby.configure({
+                     daemonize: true,
+                     stream: true,
+                     error_clamscan_client_error: true,
+                     error_clamscan_missing: true,
+                     error_file_missing: true,
+                     error_file_virus: true,
+                     config_file: '/app/config/antivirus/clamd.conf'
+                   })
 else
-  if ENV['AWS_NATIVE'] == 'true'
-    Clamby.configure({
-      daemonize: true,
-      stream: true,
-      error_clamscan_client_error: true,
-      error_clamscan_missing: true,
-      error_file_missing: true,
-      error_file_virus: true,
-      config_file: '/app/config/antivirus/clamd.conf'
-    })
-  else
-    Clamby.configure({
-      daemonize: true,
-      stream: true,
-      error_clamscan_missing: true,
-      error_file_missing: true,
-      error_file_virus: true,
-      config_file: '.apt/etc/clamav/clamd.conf',
-      output_level: 'high'
-    })
-  end
+  Clamby.configure({
+                     daemonize: true,
+                     stream: true,
+                     error_clamscan_missing: true,
+                     error_file_missing: true,
+                     error_file_virus: true,
+                     config_file: '.apt/etc/clamav/clamd.conf',
+                     output_level: 'high'
+                   })
 end

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,21 +1,32 @@
 if Rails.env.test? || Rails.env.development?
   Clamby.configure({
-                     daemonize: true,
-                     stream: true,
-                     error_clamscan_missing: true,
-                     error_file_missing: true,
-                     error_file_virus: true,
-                     output_level: 'high'
-                   })
+    daemonize: true,
+    stream: true,
+    error_clamscan_missing: true,
+    error_file_missing: true,
+    error_file_virus: true,
+    output_level: 'high'
+  })
 else
-  Clamby.configure({
-                     daemonize: true,
-                     stream: true,
-                     error_clamscan_client_error: true,
-                     error_clamscan_missing: true,
-                     error_file_missing: true,
-                     error_file_virus: true,
-                     config_file: '/app/config/antivirus/clamd.conf',
-                     output_level: 'high'
-                   })
+  if ENV['AWS_NATIVE'] == 'true'
+    Clamby.configure({
+      daemonize: true,
+      stream: true,
+      error_clamscan_client_error: true,
+      error_clamscan_missing: true,
+      error_file_missing: true,
+      error_file_virus: true,
+      config_file: '/app/config/antivirus/clamd.conf'
+    })
+  else
+    Clamby.configure({
+      daemonize: true,
+      stream: true,
+      error_clamscan_missing: true,
+      error_file_missing: true,
+      error_file_virus: true,
+      config_file: '.apt/etc/clamav/clamd.conf',
+      output_level: 'high'
+    })
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   resources :documents, only: [:update]
+  get '/health_check', to: 'health_check#index'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,47 +2,47 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `bin/rails
-# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_08_133417) do
+ActiveRecord::Schema.define(:version => 2020_12_08_133417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "clients", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "source_app", limit: 20
-    t.string "api_key", limit: 255
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+  create_table "clients", :id => :uuid, :default => -> { "gen_random_uuid()" }, :force => :cascade do |t|
+    t.string "source_app", :limit => 20
+    t.string "api_key", :limit => 255
+    t.datetime "created_at", :precision => 6, :null => false
+    t.datetime "updated_at", :precision => 6, :null => false
     t.index ["api_key"], name: "index_clients_on_api_key", unique: true
     t.index ["source_app"], name: "index_clients_on_source_app", unique: true
   end
 
-  create_table "documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "source_app", limit: 20
-    t.string "state", limit: 20
-    t.string "clamav_message", limit: 255
-    t.string "document_file", limit: 255
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+  create_table "documents", :id => :uuid, :default => -> { "gen_random_uuid()" }, :force => :cascade do |t|
+    t.string "source_app", :limit => 20
+    t.string "state", :limit => 20
+    t.string "clamav_message", :limit => 255
+    t.string "document_file", :limit => 255
+    t.datetime "created_at", :precision => 6, :null => false
+    t.datetime "updated_at", :precision => 6, :null => false
   end
 
-  create_table "unchecked_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "document_id", null: false
-    t.string "document_file", limit: 255
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.uuid "client_id", null: false
-    t.index ["client_id"], name: "index_unchecked_documents_on_client_id"
-    t.index ["document_id"], name: "index_unchecked_documents_on_document_id"
+  create_table "unchecked_documents", :id => :uuid, :default => -> { "gen_random_uuid()" }, :force => :cascade do |t|
+    t.uuid "document_id", :null => false
+    t.string "document_file", :limit => 255
+    t.datetime "created_at", :precision => 6, :null => false
+    t.datetime "updated_at", :precision => 6, :null => false
+    t.uuid "client_id", :null => false
+    t.index ["client_id"], :name => "index_unchecked_documents_on_client_id"
+    t.index ["document_id"], :name => "index_unchecked_documents_on_document_id"
   end
 
   add_foreign_key "unchecked_documents", "clients"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,47 +2,47 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 2020_12_08_133417) do
+ActiveRecord::Schema.define(version: 2020_12_08_133417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "clients", :id => :uuid, :default => -> { "gen_random_uuid()" }, :force => :cascade do |t|
-    t.string "source_app", :limit => 20
-    t.string "api_key", :limit => 255
-    t.datetime "created_at", :precision => 6, :null => false
-    t.datetime "updated_at", :precision => 6, :null => false
+  create_table "clients", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "source_app", limit: 20
+    t.string "api_key", limit: 255
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["api_key"], name: "index_clients_on_api_key", unique: true
     t.index ["source_app"], name: "index_clients_on_source_app", unique: true
   end
 
-  create_table "documents", :id => :uuid, :default => -> { "gen_random_uuid()" }, :force => :cascade do |t|
-    t.string "source_app", :limit => 20
-    t.string "state", :limit => 20
-    t.string "clamav_message", :limit => 255
-    t.string "document_file", :limit => 255
-    t.datetime "created_at", :precision => 6, :null => false
-    t.datetime "updated_at", :precision => 6, :null => false
+  create_table "documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "source_app", limit: 20
+    t.string "state", limit: 20
+    t.string "clamav_message", limit: 255
+    t.string "document_file", limit: 255
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "unchecked_documents", :id => :uuid, :default => -> { "gen_random_uuid()" }, :force => :cascade do |t|
-    t.uuid "document_id", :null => false
-    t.string "document_file", :limit => 255
-    t.datetime "created_at", :precision => 6, :null => false
-    t.datetime "updated_at", :precision => 6, :null => false
-    t.uuid "client_id", :null => false
-    t.index ["client_id"], :name => "index_unchecked_documents_on_client_id"
-    t.index ["document_id"], :name => "index_unchecked_documents_on_document_id"
+  create_table "unchecked_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "document_id", null: false
+    t.string "document_file", limit: 255
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.uuid "client_id", null: false
+    t.index ["client_id"], name: "index_unchecked_documents_on_client_id"
+    t.index ["document_id"], name: "index_unchecked_documents_on_document_id"
   end
 
   add_foreign_key "unchecked_documents", "clients"

--- a/spec/controllers/health_check_controller_spec.rb
+++ b/spec/controllers/health_check_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheckController, type: :controller do
+  describe 'GET #index' do
+    it 'returns a JSON response with status ok' do
+      get :index
+
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq('application/json; charset=utf-8')
+
+      json_response = JSON.parse(response.body)
+      expect(json_response).to eq({ 'status' => 'ok' })
+    end
+  end
+end


### PR DESCRIPTION
The purpose of this PR is to allow the application to be ran in the current prod environment as well as the AWS Native environment, so we have added an env variable called `AWS_NATIVE ` which when set to `true` will be configured to run in the AWS native environment.